### PR TITLE
[BACKLOG-11322] Resolve Security Vulnerabilities around Apache Common File Upload

### DIFF
--- a/Samples for Extending Pentaho/Reference Implementations/Security/SAML 2.0/pom.xml
+++ b/Samples for Extending Pentaho/Reference Implementations/Security/SAML 2.0/pom.xml
@@ -27,7 +27,7 @@
     <dependency.batik.version>1.7</dependency.batik.version>
     <dependency.bsh.version>2.0b4</dependency.bsh.version>
     <dependency.commons.beanutils.version>1.7.0</dependency.commons.beanutils.version>
-    <dependency.commons.fileupload.version>1.3.1</dependency.commons.fileupload.version>
+    <dependency.commons.fileupload.version>1.3.2</dependency.commons.fileupload.version>
     <dependency.javax.servlet.version>3.0.1</dependency.javax.servlet.version>
     <dependency.jaxen.version>1.1-beta-8</dependency.jaxen.version>
     <dependency.jdom.version>1.1</dependency.jdom.version>


### PR DESCRIPTION
@pentaho/rogueone Upgrade to commons-fileupload-1.3.2. Please review.
