### PR TITLE
BISERVER-14304 SAML Backport 2 Commits Squashed

### DIFF
--- a/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/documentation/resources/applicationContext-spring-security-saml.xml
+++ b/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/documentation/resources/applicationContext-spring-security-saml.xml
@@ -20,14 +20,16 @@ prohibited to anyone except those individuals and entities who have executed
 confidentiality and non-disclosure agreements or other agreements with Pentaho,
 explicitly covering such access.
 ============================================================================-->
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<beans xmlns="http://www.springframework.org/schema/beans" 
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:sec="http://www.springframework.org/schema/security"
        xmlns:pen="http://www.pentaho.com/schema/pentaho-system"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
                            http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
-                           http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.1.xsd
-       http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd" default-lazy-init="true">
+                           http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.2.xsd
+                           http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd" 
+       default-lazy-init="true">
 
 	<!-- ======================== FILTER CHAIN ======================= -->
 

--- a/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pentaho-saml/pom.xml
+++ b/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pentaho-saml/pom.xml
@@ -329,7 +329,7 @@
               javax.servlet.*,
               javax.sql.*,
               javax.xml.*,
-              org.apache.xerces.*;version="${dependency.xercesImpl.version}",
+              org.apache.xerces.*;version="${xercesImpl.version}",
               org.apache.xml.security.*;version="${dependency.xmlsec.version}",
               org.pentaho.platform.api.engine.*,
               org.pentaho.platform.api.mt.*,

--- a/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pom.xml
+++ b/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pom.xml
@@ -38,7 +38,6 @@
     <dependency.slf4j-log4j12.version>1.7.9</dependency.slf4j-log4j12.version>
     <dependency.spring.framework.version>3.2.11.RELEASE</dependency.spring.framework.version>
     <dependency.spring.security.version>3.1.4.RELEASE</dependency.spring.security.version>
-    <dependency.xercesImpl.version>2.11.0</dependency.xercesImpl.version>
     <dependency.xmlsec.version>2.0.5</dependency.xmlsec.version>
 
     <maven-bundle-plugin.version>3.0.1</maven-bundle-plugin.version>


### PR DESCRIPTION
This includes two squashed commits from Ricardo and myself in master. There is an update to applicationContext-spring-security-saml that deals with updates to Spring Security in 8.3, and an update to the xerces dependency that is wired in 8.3