### PR TITLE
[BISERVER-14574] Updated to Spring Security 5.4 to match platform update

### DIFF
--- a/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/documentation/resources/applicationContext-spring-security-saml.xml
+++ b/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/documentation/resources/applicationContext-spring-security-saml.xml
@@ -26,8 +26,8 @@ explicitly covering such access.
        xmlns:sec="http://www.springframework.org/schema/security"
        xmlns:pen="http://www.pentaho.com/schema/pentaho-system"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
-                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.1.xsd
-                           http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.2.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.3.xsd
+                           http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-5.4.xsd
                            http://www.pentaho.com/schema/pentaho-system http://www.pentaho.com/schema/pentaho-system.xsd" 
        default-lazy-init="true">
 

--- a/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pom.xml
+++ b/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pom.xml
@@ -36,8 +36,8 @@
     <dependency.org.apache.velocity.version>1.7</dependency.org.apache.velocity.version>
     <dependency.slf4j.version>1.7.3</dependency.slf4j.version>
     <dependency.slf4j-log4j12.version>1.7.9</dependency.slf4j-log4j12.version>
-    <dependency.spring.framework.version>3.2.18.RELEASE</dependency.spring.framework.version>
-    <dependency.spring.security.version>3.1.7.RELEASE</dependency.spring.security.version>
+    <dependency.spring.framework.version>5.3.3</dependency.spring.framework.version>
+    <dependency.spring.security.version>5.4.2</dependency.spring.security.version>
     <dependency.xmlsec.version>2.0.5</dependency.xmlsec.version>
 
     <maven-bundle-plugin.version>3.0.1</maven-bundle-plugin.version>


### PR DESCRIPTION
For 9.2, spring-security was updated to 5.4.2, and spring framework to 5.3.3. These have been updated in the SAML sample now that the upgrade is complete.