### PR TITLE
Allowed custom max.authentication.age and updated to 8.2.0.0-342 arti…

### DIFF
--- a/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pentaho-saml-assembly/pom.xml
+++ b/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pentaho-saml-assembly/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>pentaho</groupId>
     <artifactId>pentaho-authentication-provider-samples</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.0-342</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>pentaho-saml-sample</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.0-342</version>
   <packaging>kar</packaging>
 
   <name>Pentaho SAML Authentication Provider .kar</name>

--- a/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pentaho-saml/pom.xml
+++ b/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pentaho-saml/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>pentaho</groupId>
     <artifactId>pentaho-authentication-provider-samples</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.0-342</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pentaho-saml/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pentaho-saml/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -28,6 +28,8 @@
       <!-- END IMPORTANT NOTE -->
 
       <cm:property name="saml.valid.response.interval.in.secs" value="86400" /> <!-- 1 day in secs -->
+      
+      <cm:property name="saml.max.authentication.age.in.secs" value="7200" /> <!-- default to 2 hours in seconds -->
 
       <!-- ========================== -->
       <!-- metadata providers         -->
@@ -634,6 +636,7 @@
     <property name="responseSkew" value="${saml.valid.response.interval.in.secs}" />
     <property name="metadata" ref="metadata" />
     <property name="processor" ref="processor" />
+    <property name="maxAuthenticationAge" value="${saml.max.authentication.age.in.secs}" />
   </bean>
 
   <!-- SAML 2.0 Holder-of-Key WebSSO Assertion Consumer -->

--- a/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pentaho-saml/src/main/resources/cfg/pentaho.saml.cfg
+++ b/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pentaho-saml/src/main/resources/cfg/pentaho.saml.cfg
@@ -47,6 +47,9 @@ saml.idp.metadata.classpath=/metadata/idp/ssocircle-idp-metadata.xml
 # 1 day in secs
 saml.valid.response.interval.in.secs=86400
 
+# 2 hour max authentication age
+saml.max.authentication.age.in.secs=7200
+
 
 # ############################### #
 # user attributes mapped to roles #

--- a/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pom.xml
+++ b/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.pentaho</groupId>
     <artifactId>pentaho-ce-jar-parent-pom</artifactId>
-    <version>8.2.0.0-SNAPSHOT</version>
+    <version>8.2.0.0-342</version>
   </parent>
 
   <groupId>pentaho</groupId>
   <artifactId>pentaho-authentication-provider-samples</artifactId>
-  <version>8.2.0.0-SNAPSHOT</version>
+  <version>8.2.0.0-342</version>
   <packaging>pom</packaging>
 
   <name>Pentaho Authentication Provider Samples Base</name>


### PR DESCRIPTION
- Changed to build from 8.2.0.0-342 since 8.2.0.0-SNAPSHOT artifacts are missing
- Cherry picked max.authentication.age setting for pentaho.saml.cfg