### PR TITLE
Pentaho http resource uses get to keycloak 25

### DIFF
--- a/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pentaho-saml/src/main/java/org/pentaho/platform/spring/security/saml/resources/PentahoHttpResource.java
+++ b/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pentaho-saml/src/main/java/org/pentaho/platform/spring/security/saml/resources/PentahoHttpResource.java
@@ -1,0 +1,86 @@
+package org.pentaho.platform.spring.security.saml.resources;
+
+import java.io.IOException;
+
+import org.apache.commons.httpclient.Header;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.params.HttpConnectionManagerParams;
+import org.apache.commons.httpclient.util.DateParseException;
+import org.apache.commons.httpclient.util.DateUtil;
+import org.joda.time.DateTime;
+import org.joda.time.chrono.ISOChronology;
+import org.opensaml.util.resource.ResourceException;
+import org.opensaml.xml.util.DatatypeHelper;
+
+public class PentahoHttpResource extends org.opensaml.util.resource.HttpResource {
+
+    private final String resourceUrl;
+    private final HttpClient httpClient;
+
+    public PentahoHttpResource(String resource) {
+        super(resource);
+        resourceUrl = DatatypeHelper.safeTrimOrNullString(resource);
+        if (resourceUrl == null) {
+            throw new IllegalArgumentException("Resource URL may not be null or empty");
+        } else {
+            httpClient = new HttpClient();
+            HttpConnectionManagerParams connMgrParams = httpClient.getHttpConnectionManager().getParams();
+            connMgrParams.setConnectionTimeout(90000);
+            connMgrParams.setSoTimeout(90000);
+        }
+    }
+
+    @Override
+    public boolean exists() throws ResourceException {
+        GetMethod getMethod = new GetMethod(super.getLocation());
+        getMethod.addRequestHeader("Connection", "close");
+        getMethod.addRequestHeader("Accept", "*/*");
+
+        boolean var8;
+        try {
+            this.httpClient.executeMethod(getMethod);
+            if (getMethod.getStatusCode() != 200) {
+                var8 = false;
+                return var8;
+            }
+            var8 = true;
+        } catch (IOException e) {
+            throw new ResourceException("Unable to contact resource URL: " + this.resourceUrl, e);
+        } finally {
+            getMethod.releaseConnection();
+        }
+        return var8;
+    }
+    @Override
+    public DateTime getLastModifiedTime() throws ResourceException {
+        GetMethod getMethod = new GetMethod(this.resourceUrl);
+        getMethod.addRequestHeader("Connection", "close");
+        getMethod.addRequestHeader("Accept", "*/*");
+
+        DateTime dateTime;
+        try {
+            this.httpClient.executeMethod(getMethod);
+            if (getMethod.getStatusCode() != 200) {
+                throw new ResourceException("Unable to retrieve resource URL " + this.resourceUrl + ", received HTTP status code " + getMethod.getStatusCode());
+            }
+
+            Header lastModifiedHeader = getMethod.getResponseHeader("Last-Modified");
+            if (lastModifiedHeader == null || DatatypeHelper.isEmpty(lastModifiedHeader.getValue())) {
+                dateTime = new DateTime();
+                return dateTime;
+            }
+
+
+            long lastModifiedTime = DateUtil.parseDate(lastModifiedHeader.getValue()).getTime();
+            dateTime = new DateTime(lastModifiedTime, ISOChronology.getInstanceUTC());
+        } catch (IOException e) {
+            throw new ResourceException("Unable to contact resource URL: " + this.resourceUrl, e);
+        } catch (DateParseException e) {
+            throw new ResourceException("Unable to parse last modified date for resource:" + this.resourceUrl, e);
+        } finally {
+            getMethod.releaseConnection();
+        }
+        return dateTime;
+    }
+}

--- a/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pentaho-saml/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/Samples_for_Extending_Pentaho/Reference Implementations/Security/SAML 2.0/pentaho-saml/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -540,7 +540,7 @@
   <bean id="spResourceFactory" class="org.pentaho.platform.spring.security.saml.resources.MetadataResourceFactory">
     <argument>
       <map key-type="java.lang.String" value-type="java.lang.String">
-        <entry key="org.opensaml.util.resource.HttpResource" value="${saml.sp.metadata.url}" />
+        <entry key="org.pentaho.platform.spring.security.saml.resources.PentahoHttpResource" value="${saml.sp.metadata.url}" />
         <entry key="org.opensaml.util.resource.FilesystemResource" value="${saml.sp.metadata.filesystem}" />
         <entry key="org.opensaml.util.resource.ClasspathResource" value="${saml.sp.metadata.classpath}" />
       </map>
@@ -551,7 +551,7 @@
   <bean id="idpResourceFactory" class="org.pentaho.platform.spring.security.saml.resources.MetadataResourceFactory">
     <argument>
       <map key-type="java.lang.String" value-type="java.lang.String">
-        <entry key="org.opensaml.util.resource.HttpResource" value="${saml.idp.metadata.url}" />
+        <entry key="org.pentaho.platform.spring.security.saml.resources.PentahoHttpResource" value="${saml.sp.metadata.url}" />
         <entry key="org.opensaml.util.resource.FilesystemResource" value="${saml.idp.metadata.filesystem}" />
         <entry key="org.opensaml.util.resource.ClasspathResource" value="${saml.idp.metadata.classpath}" />
       </map>


### PR DESCRIPTION
This is a well working fix while introducing a PentahoHttpResource.class extends org.opensaml.util.resource.HttpResource.
HttpResource from org.opensaml.util.resource.HttpResource uses HEAD-Request without authentication, which is forbidden by Keycloak at least in version 25. 
Both methods using HEAD calls to KC25  are overidden and use unauthenticated GET calls instead to KC25 which are still allowed against KC25 for existende check. 